### PR TITLE
Add custom cost type support for project costs

### DIFF
--- a/client/pages/Project.tsx
+++ b/client/pages/Project.tsx
@@ -208,10 +208,20 @@ export default function ProjectPage() {
   if (error || !snapshot) {
     return (
       <Layout>
-        <div className="p-6">تعذر العثور على المشروع</div>
+        <div className="p-6">تعذر العثو�� على المشروع</div>
       </Layout>
     );
   }
+
+  const getCostTypeLabel = (cost: ProjectCost) => {
+    if (cost.customTypeLabel && cost.customTypeLabel.trim()) {
+      return cost.customTypeLabel;
+    }
+    if (cost.type === "construction") return "إنشاء";
+    if (cost.type === "operation") return "تشغيل";
+    if (cost.type === "expense") return "مصروفات";
+    return "أخرى";
+  };
 
   const p = snapshot.project;
 
@@ -319,7 +329,7 @@ export default function ProjectPage() {
           </div>
 
           <div className="bg-white border border-slate-200 rounded-xl p-4 shadow">
-            <h3 className="font-semibold mb-3">ت��جيل بيع وإصدار فاتورة</h3>
+            <h3 className="font-semibold mb-3">تسجيل بيع وإصدار فاتورة</h3>
             <div className="grid gap-3">
               <div className="grid grid-cols-2 gap-3">
                 <input

--- a/client/pages/Project.tsx
+++ b/client/pages/Project.tsx
@@ -83,7 +83,7 @@ export default function ProjectPage() {
     if (!newCost.amount) return toast.error("المبلغ مطلوب");
     const amount = Number(newCost.amount);
     if (!Number.isFinite(amount) || amount <= 0)
-      return toast.error("قيمة غ��ر صحيحة");
+      return toast.error("قيمة غير صحيحة");
     const customTypeLabel =
       newCost.type === "other" ? newCost.customTypeLabel.trim() : undefined;
     if (newCost.type === "other" && !customTypeLabel) {
@@ -248,16 +248,19 @@ export default function ProjectPage() {
                 <select
                   className="w-full rounded-md border-2 border-slate-200 focus:border-indigo-500 outline-none px-3 py-2"
                   value={newCost.type}
-                  onChange={(e) =>
-                    setNewCost({
-                      ...newCost,
-                      type: e.target.value as ProjectCost["type"],
-                    })
-                  }
+                  onChange={(e) => {
+                    const value = e.target.value as ProjectCost["type"];
+                    setNewCost((prev) => ({
+                      ...prev,
+                      type: value,
+                      customTypeLabel: value === "other" ? prev.customTypeLabel : "",
+                    }));
+                  }}
                 >
                   <option value="construction">إنشاء</option>
                   <option value="operation">تشغيل</option>
                   <option value="expense">مصروفات</option>
+                  <option value="other">أخرى</option>
                 </select>
                 <input
                   className="w-full rounded-md border-2 border-slate-200 focus:border-indigo-500 outline-none px-3 py-2"

--- a/client/pages/Project.tsx
+++ b/client/pages/Project.tsx
@@ -83,7 +83,7 @@ export default function ProjectPage() {
     if (!newCost.amount) return toast.error("المبلغ مطلوب");
     const amount = Number(newCost.amount);
     if (!Number.isFinite(amount) || amount <= 0)
-      return toast.error("قيمة غير صحيحة");
+      return toast.error("قيمة غ��ر صحيحة");
     const customTypeLabel =
       newCost.type === "other" ? newCost.customTypeLabel.trim() : undefined;
     if (newCost.type === "other" && !customTypeLabel) {
@@ -293,14 +293,7 @@ export default function ProjectPage() {
                   {savingCost ? "جاري التسجيل..." : "تسجيل التكلفة"}
                 </button>
                 <button
-                  onClick={() =>
-                    setNewCost({
-                      type: "construction",
-                      amount: "",
-                      date: today(),
-                      note: "",
-                    })
-                  }
+                  onClick={() => setNewCost(makeNewCostState())}
                   className="rounded-md border px-3 py-2 bg-white"
                 >
                   إعادة تعيين

--- a/client/pages/Project.tsx
+++ b/client/pages/Project.tsx
@@ -27,12 +27,14 @@ export default function ProjectPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const [newCost, setNewCost] = useState({
+  const makeNewCostState = () => ({
     type: "construction" as ProjectCost["type"],
     amount: "",
     date: today(),
     note: "",
+    customTypeLabel: "",
   });
+  const [newCost, setNewCost] = useState(makeNewCostState);
   const [savingCost, setSavingCost] = useState(false);
 
   const [newSale, setNewSale] = useState({

--- a/client/pages/Project.tsx
+++ b/client/pages/Project.tsx
@@ -271,6 +271,19 @@ export default function ProjectPage() {
                   }
                 />
               </div>
+              {newCost.type === "other" ? (
+                <input
+                  className="w-full rounded-md border-2 border-slate-200 focus:border-indigo-500 outline-none px-3 py-2"
+                  placeholder="حدد نوع التكلفة"
+                  value={newCost.customTypeLabel}
+                  onChange={(e) =>
+                    setNewCost((prev) => ({
+                      ...prev,
+                      customTypeLabel: e.target.value,
+                    }))
+                  }
+                />
+              ) : null}
               <input
                 type="date"
                 className="w-full rounded-md border-2 border-slate-200 focus:border-indigo-500 outline-none px-3 py-2"
@@ -306,7 +319,7 @@ export default function ProjectPage() {
           </div>
 
           <div className="bg-white border border-slate-200 rounded-xl p-4 shadow">
-            <h3 className="font-semibold mb-3">تسجيل بيع وإصدار فاتورة</h3>
+            <h3 className="font-semibold mb-3">ت��جيل بيع وإصدار فاتورة</h3>
             <div className="grid gap-3">
               <div className="grid grid-cols-2 gap-3">
                 <input

--- a/client/pages/Project.tsx
+++ b/client/pages/Project.tsx
@@ -263,7 +263,8 @@ export default function ProjectPage() {
                     setNewCost((prev) => ({
                       ...prev,
                       type: value,
-                      customTypeLabel: value === "other" ? prev.customTypeLabel : "",
+                      customTypeLabel:
+                        value === "other" ? prev.customTypeLabel : "",
                     }));
                   }}
                 >

--- a/client/pages/Project.tsx
+++ b/client/pages/Project.tsx
@@ -84,12 +84,18 @@ export default function ProjectPage() {
     const amount = Number(newCost.amount);
     if (!Number.isFinite(amount) || amount <= 0)
       return toast.error("قيمة غير صحيحة");
+    const customTypeLabel =
+      newCost.type === "other" ? newCost.customTypeLabel.trim() : undefined;
+    if (newCost.type === "other" && !customTypeLabel) {
+      return toast.error("يرجى إدخال نوع التكلفة");
+    }
     try {
       setSavingCost(true);
       const res = await createProjectCost({
         projectId: id,
         projectName: snapshot.project.name,
         type: newCost.type,
+        customTypeLabel,
         amount,
         date: newCost.date,
         note: newCost.note,
@@ -99,7 +105,7 @@ export default function ProjectPage() {
       setSnapshot((prev) =>
         prev ? { ...prev, costs: [res.cost, ...prev.costs] } : prev,
       );
-      setNewCost({ type: "construction", amount: "", date: today(), note: "" });
+      setNewCost(makeNewCostState());
       toast.success("تم تسجيل التكلفة");
     } catch (e) {
       const msg = e instanceof Error ? e.message : "تعذر التسجيل";

--- a/client/pages/Project.tsx
+++ b/client/pages/Project.tsx
@@ -208,7 +208,7 @@ export default function ProjectPage() {
   if (error || !snapshot) {
     return (
       <Layout>
-        <div className="p-6">تعذر العثو�� على المشروع</div>
+        <div className="p-6">تعذر العثور على المشروع</div>
       </Layout>
     );
   }
@@ -441,13 +441,7 @@ export default function ProjectPage() {
                   {snapshot.costs.map((c) => (
                     <tr key={c.id} className="border-t">
                       <td className="px-3 py-2">{c.date}</td>
-                      <td className="px-3 py-2">
-                        {c.type === "construction"
-                          ? "إنشاء"
-                          : c.type === "operation"
-                            ? "تشغيل"
-                            : "مصروفات"}
-                      </td>
+                      <td className="px-3 py-2">{getCostTypeLabel(c)}</td>
                       <td className="px-3 py-2">{c.amount.toLocaleString()}</td>
                       <td className="px-3 py-2">{c.note}</td>
                     </tr>

--- a/server/routes/accounting.ts
+++ b/server/routes/accounting.ts
@@ -378,12 +378,16 @@ export const createProjectCostHandler: RequestHandler = async (req, res) => {
     respondError(res, 400, "Invalid amount");
     return;
   }
-  const customTypeLabel =
+  const customTypeLabelRaw =
     typeof body.customTypeLabel === "string" ? body.customTypeLabel : null;
-  if (body.type === "other" && (!customTypeLabel || !customTypeLabel.trim())) {
+  if (
+    body.type === "other" &&
+    (!customTypeLabelRaw || !customTypeLabelRaw.trim())
+  ) {
     respondError(res, 400, "Custom type label required");
     return;
   }
+  const customTypeLabel = body.type === "other" ? customTypeLabelRaw : null;
   try {
     const result = await createProjectCostStore({
       projectId: String(projectId),

--- a/server/routes/accounting.ts
+++ b/server/routes/accounting.ts
@@ -389,6 +389,7 @@ export const createProjectCostHandler: RequestHandler = async (req, res) => {
       projectId: String(projectId),
       projectName: String(body.projectName),
       type: body.type,
+      customTypeLabel,
       amount,
       date: String(body.date),
       note: body.note ?? "",

--- a/server/routes/accounting.ts
+++ b/server/routes/accounting.ts
@@ -373,6 +373,16 @@ export const createProjectCostHandler: RequestHandler = async (req, res) => {
     respondError(res, 400, "Missing required fields");
     return;
   }
+  const allowedCostTypes = new Set([
+    "construction",
+    "operation",
+    "expense",
+    "other",
+  ]);
+  if (!allowedCostTypes.has(body.type as string)) {
+    respondError(res, 400, "Invalid cost type");
+    return;
+  }
   const amount = ensureNumber(body.amount);
   if (!Number.isFinite(amount) || amount <= 0) {
     respondError(res, 400, "Invalid amount");

--- a/server/routes/accounting.ts
+++ b/server/routes/accounting.ts
@@ -378,6 +378,12 @@ export const createProjectCostHandler: RequestHandler = async (req, res) => {
     respondError(res, 400, "Invalid amount");
     return;
   }
+  const customTypeLabel =
+    typeof body.customTypeLabel === "string" ? body.customTypeLabel : null;
+  if (body.type === "other" && (!customTypeLabel || !customTypeLabel.trim())) {
+    respondError(res, 400, "Custom type label required");
+    return;
+  }
   try {
     const result = await createProjectCostStore({
       projectId: String(projectId),

--- a/server/store/accounting.ts
+++ b/server/store/accounting.ts
@@ -823,19 +823,22 @@ export async function createProjectCost(
 ): Promise<ProjectCostCreateResult> {
   const pool = await getInitializedMysqlPool();
   if (!pool) {
+    const customTypeLabel = normalizeCustomTypeLabel(input.customTypeLabel);
+    const note = typeof input.note === "string" ? input.note : "";
     const cost: ProjectCost = {
       id: crypto.randomUUID(),
       projectId: input.projectId,
       type: input.type,
+      customTypeLabel,
       amount: input.amount,
       date: input.date,
-      note: input.note,
+      note,
     };
     fallbackStore.costs.set(cost.id, cost);
     const transaction = createTransactionFallback({
       date: input.date,
       type: "expense",
-      description: `تكلفة ${projectCostTypeLabel(input.type)} لمشروع ${input.projectName}`,
+      description: `تكلفة ${projectCostTypeLabel(input.type, customTypeLabel)} لمشروع ${input.projectName}`,
       amount: input.amount,
       approved: input.approved,
       createdBy: input.createdBy ?? null,

--- a/server/store/accounting.ts
+++ b/server/store/accounting.ts
@@ -855,14 +855,7 @@ export async function createProjectCost(
     await conn.query(
       `INSERT INTO project_costs (id, project_id, type, amount, date, note)
        VALUES (?, ?, ?, ?, ?, ?)`,
-      [
-        id,
-        input.projectId,
-        input.type,
-        input.amount,
-        input.date,
-        storedNote,
-      ],
+      [id, input.projectId, input.type, input.amount, input.date, storedNote],
     );
     const [rows] = await conn.query<ProjectCostRow[]>(
       `SELECT id, project_id, type, amount, date, note, created_at

--- a/server/store/accounting.ts
+++ b/server/store/accounting.ts
@@ -67,7 +67,7 @@ interface ProjectRow extends RowDataPacket {
 interface ProjectCostRow extends RowDataPacket {
   id: string;
   project_id: string;
-  type: "construction" | "operation" | "expense";
+  type: ProjectCostType;
   amount: number | string;
   date: string | Date;
   note: string | null;

--- a/server/store/accounting.ts
+++ b/server/store/accounting.ts
@@ -962,8 +962,13 @@ export async function createProjectSale(
   }
 }
 
-function projectCostTypeLabel(type: "construction" | "operation" | "expense") {
+function projectCostTypeLabel(
+  type: ProjectCostType,
+  customTypeLabel?: string | null,
+) {
   if (type === "construction") return "إنشاء";
   if (type === "operation") return "تشغيل";
-  return "مصروفات";
+  if (type === "expense") return "مصروفات";
+  const normalized = normalizeCustomTypeLabel(customTypeLabel);
+  return normalized ?? "أخرى";
 }

--- a/server/store/accounting.ts
+++ b/server/store/accounting.ts
@@ -861,7 +861,7 @@ export async function createProjectCost(
         input.type,
         input.amount,
         input.date,
-        input.note || null,
+        storedNote,
       ],
     );
     const [rows] = await conn.query<ProjectCostRow[]>(

--- a/server/store/accounting.ts
+++ b/server/store/accounting.ts
@@ -95,6 +95,51 @@ const fallbackStore = {
   sales: new Map<string, ProjectSale>(),
 };
 
+type ProjectCostNoteData = {
+  note: string;
+  customTypeLabel: string | null;
+};
+
+function normalizeCustomTypeLabel(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function parseProjectCostNote(raw: string | null): ProjectCostNoteData {
+  if (!raw) {
+    return { note: "", customTypeLabel: null };
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      const data = parsed as Record<string, unknown>;
+      return {
+        note: typeof data.note === "string" ? data.note : "",
+        customTypeLabel: normalizeCustomTypeLabel(data.customTypeLabel),
+      };
+    }
+  } catch {
+    // not JSON, treat as plain note
+  }
+  return { note: raw, customTypeLabel: null };
+}
+
+function serializeProjectCostNote(
+  note: string,
+  customTypeLabel: string | null,
+): string | null {
+  const normalizedLabel = normalizeCustomTypeLabel(customTypeLabel);
+  const noteValue = typeof note === "string" ? note : "";
+  if (!normalizedLabel) {
+    return noteValue ? noteValue : null;
+  }
+  return JSON.stringify({
+    note: noteValue,
+    customTypeLabel: normalizedLabel,
+  });
+}
+
 function asNumber(value: unknown): number {
   if (value === null || value === undefined) return 0;
   if (typeof value === "number") return value;

--- a/server/store/accounting.ts
+++ b/server/store/accounting.ts
@@ -873,7 +873,7 @@ export async function createProjectCost(
       {
         date: input.date,
         type: "expense",
-        description: `تكلفة ${projectCostTypeLabel(input.type)} لمشروع ${input.projectName}`,
+        description: `تكلفة ${projectCostTypeLabel(input.type, customTypeLabel)} لمشروع ${input.projectName}`,
         amount: input.amount,
         approved: input.approved,
         createdBy: input.createdBy ?? null,

--- a/server/store/accounting.ts
+++ b/server/store/accounting.ts
@@ -11,6 +11,7 @@ import {
   type Project,
   type ProjectCost,
   type ProjectCostCreateInput,
+  type ProjectCostType,
   type ProjectCostCreateResult,
   type ProjectCreateInput,
   type ProjectSale,

--- a/server/store/accounting.ts
+++ b/server/store/accounting.ts
@@ -848,6 +848,9 @@ export async function createProjectCost(
   const conn = await pool.getConnection();
   try {
     await conn.beginTransaction();
+    const customTypeLabel = normalizeCustomTypeLabel(input.customTypeLabel);
+    const note = typeof input.note === "string" ? input.note : "";
+    const storedNote = serializeProjectCostNote(note, customTypeLabel);
     const id = crypto.randomUUID();
     await conn.query(
       `INSERT INTO project_costs (id, project_id, type, amount, date, note)

--- a/server/store/accounting.ts
+++ b/server/store/accounting.ts
@@ -226,13 +226,15 @@ function mapProjectRow(row: ProjectRow): Project {
 }
 
 function mapProjectCostRow(row: ProjectCostRow): ProjectCost {
+  const noteData = parseProjectCostNote(row.note ?? null);
   return {
     id: row.id,
     projectId: row.project_id,
     type: row.type,
+    customTypeLabel: noteData.customTypeLabel,
     amount: asNumber(row.amount),
     date: formatDate(row.date),
-    note: row.note ?? "",
+    note: noteData.note,
   };
 }
 
@@ -618,7 +620,7 @@ export async function recordInventoryIssue(
     const transaction = createTransactionFallback({
       date: input.date,
       type: "expense",
-      description: `صرف ${item.name} لمشروع ${input.project} (${input.qty} ${item.unit} × ${input.unitPrice})`,
+      description: `صرف ${item.name} لمشر��ع ${input.project} (${input.qty} ${item.unit} × ${input.unitPrice})`,
       amount: movement.total,
       approved: input.approved,
       createdBy: input.createdBy ?? null,

--- a/shared/accounting.ts
+++ b/shared/accounting.ts
@@ -40,10 +40,13 @@ export interface Project {
   createdAt: string;
 }
 
+export type ProjectCostType = "construction" | "operation" | "expense" | "other";
+
 export interface ProjectCost {
   id: string;
   projectId: string;
-  type: "construction" | "operation" | "expense";
+  type: ProjectCostType;
+  customTypeLabel?: string | null;
   amount: number;
   date: string;
   note: string;
@@ -130,7 +133,8 @@ export interface ProjectCreateInput {
 export interface ProjectCostCreateInput {
   projectId: string;
   projectName: string;
-  type: "construction" | "operation" | "expense";
+  type: ProjectCostType;
+  customTypeLabel?: string | null;
   amount: number;
   date: string;
   note: string;

--- a/shared/accounting.ts
+++ b/shared/accounting.ts
@@ -40,7 +40,11 @@ export interface Project {
   createdAt: string;
 }
 
-export type ProjectCostType = "construction" | "operation" | "expense" | "other";
+export type ProjectCostType =
+  | "construction"
+  | "operation"
+  | "expense"
+  | "other";
 
 export interface ProjectCost {
   id: string;


### PR DESCRIPTION
## Changes Made

### Frontend (Project.tsx)
- Added `customTypeLabel` field to the new cost state object
- Refactored cost state initialization into `makeNewCostState()` function
- Added "other" option to the cost type dropdown
- Implemented conditional input field for custom type label when "other" is selected
- Added validation to require custom type label when "other" type is selected
- Created `getCostTypeLabel()` helper function to display appropriate labels in the costs table
- Updated cost type change handler to clear custom type label when switching away from "other"

### Backend (accounting.ts route)
- Added validation for allowed cost types including the new "other" type
- Added validation to require custom type label when cost type is "other"
- Updated `createProjectCostStore` call to include `customTypeLabel` parameter

### Backend (accounting.ts store)
- Updated `ProjectCostType` to include "other" as a valid type
- Added `ProjectCostNoteData` interface for structured note storage
- Implemented JSON serialization/deserialization for storing custom type labels in the note field
- Added helper functions: `normalizeCustomTypeLabel()`, `parseProjectCostNote()`, `serializeProjectCostNote()`
- Updated `mapProjectCostRow()` to extract custom type label from stored note data
- Modified `createProjectCost()` to handle custom type labels in both fallback and database modes
- Updated `projectCostTypeLabel()` function to support custom type labels

### Shared Types (accounting.ts)
- Defined `ProjectCostType` union type including "other"
- Added `customTypeLabel` optional field to `ProjectCost` interface
- Added `customTypeLabel` optional field to `ProjectCostCreateInput` interface

## Technical Notes
- Custom type labels are stored as JSON in the existing note field to maintain backward compatibility
- The implementation gracefully handles both old plain text notes and new structured note data
- Validation ensures custom type labels are required and non-empty when "other" type is selected

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8d5e49f2c090423eaa27fb60a2504390/pulse-studio)

👀 [Preview Link](https://8d5e49f2c090423eaa27fb60a2504390-pulse-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8d5e49f2c090423eaa27fb60a2504390</projectId>-->
<!--<branchName>pulse-studio</branchName>-->